### PR TITLE
Removed LiveReload script from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,7 +485,6 @@
       </section>
     </div>
 
-    <script src="http://localhost:35729/livereload.js"></script>
     <script src="./assets/docs.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The reference to localhost is causing the browser to hang when no server is running there.