### PR TITLE
Support for strictMath option within LESS

### DIFF
--- a/less/flag-icon-base.less
+++ b/less/flag-icon-base.less
@@ -8,7 +8,7 @@
   .flag-icon-background;
   position: relative;
   display: inline-block;
-  width: unit(4 / 3, em);
+  width: unit((4 / 3), em);
   line-height: 1em;
   &:before {
     content: "\00a0";


### PR DESCRIPTION
The less option `strictMath` requires all mathematical expressions are wrapped in parenthesis.  This will currently fail under that option.

Adding this parenthesis around the expression fixes this