### PR TITLE
Allow to exclude squared flags from build

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ need from the
 [`flag-icon-list.less`](https://github.com/lipis/flag-icon-css/blob/master/less/flag-icon-list.less)
 file and build it again.
 
+To generate only the 4x3 variant of the flags set the `flag-icon-include-square-flags`
+variable to false and rebuild your less/sass files.
+
 Credits
 -------
 

--- a/less/flag-icon-base.less
+++ b/less/flag-icon-base.less
@@ -13,7 +13,7 @@
   &:before {
     content: "\00a0";
   }
-  &.flag-icon-squared {
+  &.flag-icon-squared when (@flag-icon-include-square-flags = true) {
     width: 1em;
   }
 }
@@ -21,7 +21,7 @@
 .flag-icon(@country) {
   .flag-icon-@{country} {
     background-image: ~"url(@{flag-icon-css-path}@{flag-icon-rect-path}/@{country}.svg)";
-    &.flag-icon-squared {
+    &.flag-icon-squared when (@flag-icon-include-square-flags = true) {
       background-image: ~"url(@{flag-icon-css-path}@{flag-icon-square-path}/@{country}.svg)";
     }
   }

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,3 +1,4 @@
 @flag-icon-css-path: '../flags';
 @flag-icon-rect-path: '/4x3';
 @flag-icon-square-path: '/1x1';
+@flag-icon-include-square-flags: true;

--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -13,16 +13,20 @@
   &:before {
     content: '\00a0';
   }
-  &.flag-icon-squared {
-    width: 1em;
+  @if $flag-icon-include-square-flags {
+    &.flag-icon-squared {
+      width: 1em;
+    }
   }
 }
 
 @mixin flag-icon($country) {
   .flag-icon-#{$country} {
     background-image: url(#{$flag-icon-css-path}#{$flag-icon-rect-path}/#{$country}.svg);
-    &.flag-icon-squared {
-      background-image: url(#{$flag-icon-css-path}#{$flag-icon-square-path}/#{$country}.svg);
+    @if $flag-icon-include-square-flags {
+      &.flag-icon-squared {
+        background-image: url(#{$flag-icon-css-path}#{$flag-icon-square-path}/#{$country}.svg);
+      }
     }
   }
 }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,3 +1,4 @@
 $flag-icon-css-path: '../flags' !default;
 $flag-icon-rect-path: '/4x3' !default;
 $flag-icon-square-path: '/1x1' !default;
+$flag-icon-include-square-flags: true !default;


### PR DESCRIPTION
In our project we inline some small images using data uri but we dont use the squared variant of the flags and they only increase the resulting css file. This PR adds a variable called `flag-icon-include-square-flags` to exclude them from being generated to the target file.