### PR TITLE
German and Italian Flag Fixes

### DIFF
--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,7 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" version="1">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#fc0" d="M0 341.338h512.005v170.67H0z"/>
-    <path d="M0 0h512.005v170.67H0z"/>
-    <path fill="red" d="M0 170.67h512.005v170.668H0z"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" viewBox="0 0 3 3">
+	<rect id="black_stripe" width="3" height="3" y="0" x="0" fill="#000"/>
+	<rect id="red_stripe" width="3" height="2" y="1" x="0" fill="#D00"/>
+	<rect id="gold_stripe" width="3" height="1" y="2" x="0" fill="#FFCE00"/>
 </svg>

--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" viewBox="0 0 3 3">
-	<rect id="black_stripe" width="3" height="3" y="0" x="0" fill="#000"/>
-	<rect id="red_stripe" width="3" height="2" y="1" x="0" fill="#D00"/>
-	<rect id="gold_stripe" width="3" height="1" y="2" x="0" fill="#FFCE00"/>
+  <path d="M0 0h3v3H0z"/>
+  <path fill="#D00" d="M0 1h3v2H0z"/>
+  <path fill="#FFCE00" d="M0 2h3v1H0z"/>
 </svg>

--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" version="1">
   <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#FFCE00" d="M0 341.338h512.005v170.67H0z"/>
+    <path fill="#ffce00" d="M0 341.338h512.005v170.67H0z"/>
     <path d="M0 0h512.005v170.67H0z"/>
-    <path fill="#D00" d="M0 170.67h512.005v170.668H0z"/>
+    <path fill="#d00" d="M0 170.67h512.005v170.668H0z"/>
   </g>
 </svg>

--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,5 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" viewBox="0 0 3 3">
-  <path d="M0 0h3v3H0z"/>
-  <path fill="#D00" d="M0 1h3v2H0z"/>
-  <path fill="#FFCE00" d="M0 2h3v1H0z"/>
+<svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" version="1">
+  <g fill-rule="evenodd" stroke-width="1pt">
+    <path fill="#FFCE00" d="M0 341.338h512.005v170.67H0z"/>
+    <path d="M0 0h512.005v170.67H0z"/>
+    <path fill="#D00" d="M0 170.67h512.005v170.668H0z"/>
+  </g>
 </svg>

--- a/flags/1x1/it.svg
+++ b/flags/1x1/it.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" version="1">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h512.005v512H0z"/>
-    <path fill="#005700" d="M0 0h170.667v512H0z"/>
-    <path fill="#fc0000" d="M341.333 0H512v512H341.333z"/>
+    <path fill="#009246" d="M0 0h170.667v512H0z"/>
+    <path fill="#ce2b37" d="M341.333 0H512v512H341.333z"/>
   </g>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" version="1">
   <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#FFCE00" d="M0 320h640v160.002H0z"/>
+    <path fill="#ffce00" d="M0 320h640v160.002H0z"/>
     <path d="M0 0h640v160H0z"/>
-    <path fill="#D00" d="M0 160h640v160H0z"/>
+    <path fill="#d00" d="M0 160h640v160H0z"/>
   </g>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" viewBox="0 0 5 3">
-	<rect id="black_stripe" width="5" height="3" y="0" x="0" fill="#000"/>
-	<rect id="red_stripe" width="5" height="2" y="1" x="0" fill="#D00"/>
-	<rect id="gold_stripe" width="5" height="1" y="2" x="0" fill="#FFCE00"/>
+  <path d="M0 0h5v3H0z"/>
+  <path fill="#D00" d="M0 1h5v2H0z"/>
+  <path fill="#FFCE00" d="M0 2h5v1H0z"/>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,5 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" viewBox="0 0 5 3">
-  <path d="M0 0h5v3H0z"/>
-  <path fill="#D00" d="M0 1h5v2H0z"/>
-  <path fill="#FFCE00" d="M0 2h5v1H0z"/>
+<svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" version="1">
+  <g fill-rule="evenodd" stroke-width="1pt">
+    <path fill="#FFCE00" d="M0 320h640v160.002H0z"/>
+    <path d="M0 0h640v160H0z"/>
+    <path fill="#D00" d="M0 160h640v160H0z"/>
+  </g>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,7 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" version="1">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#fc0" d="M0 320h640v160.002H0z"/>
-    <path d="M0 0h640v160H0z"/>
-    <path fill="red" d="M0 160h640v160H0z"/>
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" viewBox="0 0 5 3">
+	<rect id="black_stripe" width="5" height="3" y="0" x="0" fill="#000"/>
+	<rect id="red_stripe" width="5" height="2" y="1" x="0" fill="#D00"/>
+	<rect id="gold_stripe" width="5" height="1" y="2" x="0" fill="#FFCE00"/>
 </svg>

--- a/flags/4x3/it.svg
+++ b/flags/4x3/it.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" version="1">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h640v479.997H0z"/>
-    <path fill="#005700" d="M0 0h213.331v479.997H0z"/>
-    <path fill="#fc0000" d="M426.663 0h213.331v479.997H426.663z"/>
+    <path fill="#009246" d="M0 0h213.331v479.997H0z"/>
+    <path fill="#ce2b37" d="M426.663 0h213.331v479.997H426.663z"/>
   </g>
 </svg>


### PR DESCRIPTION
When displaying the flag on a webpage that is output on an external SDI monitor, the colour as well as the position of the bars changes. On the internal screen or any normal HDMI screen this is not the case. While I am not entirely sure what the problem is, this pull request seems to fix the issue. I assume that a specific colour was not broadcast safe, and could not be adequately transmitted via SDI.