### PR TITLE
added class for background flag

### DIFF
--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -1,11 +1,11 @@
-@mixin flag-icon-background {
+.flag-icon-background {
   background-size: contain;
   background-position: 50%;
   background-repeat: no-repeat;
 }
 
 .flag-icon {
-  @include flag-icon-background();
+  @extend .flag-icon-background;
   position: relative;
   display: inline-block;
   width: (4 / 3) * 1em;

--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -26,7 +26,3 @@
     }
   }
 }
-
-.flag-icon-background {
-  @include flag-icon-background();
-}

--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -26,3 +26,7 @@
     }
   }
 }
+
+.flag-icon-background {
+  @include flag-icon-background();
+}


### PR DESCRIPTION
It's listed in the docs as an available class but it seems to be missing from the Sass files.

I would update the Less files (if needed) but I've not used less in so long, that I don't want to break things!