### PR TITLE
Flag of Nigeria (#388)

### DIFF
--- a/flags/1x1/ng.svg
+++ b/flags/1x1/ng.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="512" width="512" viewBox="0 0 512 512">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h511.98v511.984H0z"/>
-    <path fill="#36a100" d="M341.32 0h170.66v511.984H341.32zM0 0h170.66v511.984H0z"/>
+    <path fill="#008753" d="M341.32 0h170.66v511.984H341.32zM0 0h170.66v511.984H0z"/>
   </g>
 </svg>

--- a/flags/4x3/ng.svg
+++ b/flags/4x3/ng.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="480" width="640" viewBox="0 0 640 480">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h639.98v479.998H0z"/>
-    <path fill="#36a100" d="M426.654 0H639.98v479.998H426.654zM0 0h213.327v479.998H0z"/>
+    <path fill="#008753" d="M426.654 0H639.98v479.998H426.654zM0 0h213.327v479.998H0z"/>
   </g>
 </svg>


### PR DESCRIPTION
Changed the HEX code for both 1x1 and 4x3 Nigeria flags from #36a100(incorrect) to #008753(correct)