### PR TITLE
Rename variable $include to $flag-icon-custom, added example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,17 @@ To serve it on `localhost:8000`
 $ grunt connect
 ```
 
+#### LESS
+
 To have only specific countries in the css file, remove the ones that you don't
 need from the
 [`flag-icon-list.less`](https://github.com/lipis/flag-icon-css/blob/master/less/flag-icon-list.less)
 file and build it again.
+
+#### SCSS/SASS
+
+To import only specific countries in the css file, set the variable `$flag-icon-custom: en, de, fr;`
+
 
 ## Credits
 

--- a/sass/_flag-icon-list.scss
+++ b/sass/_flag-icon-list.scss
@@ -1,5 +1,5 @@
-@if variable-exists(include) {
-  @each $country in $include {
+@if variable-exists(flag-icon-custom) {
+  @each $country in $flag-icon-custom {
     @include flag-icon($country);
   }
 } @else {

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,3 +1,4 @@
 $flag-icon-css-path: '../flags' !default;
 $flag-icon-rect-path: '/4x3' !default;
 $flag-icon-square-path: '/1x1' !default;
+//$flag-icon-custom: en, de, fr !default;


### PR DESCRIPTION
Rename the SASS variable `$include` to `$flag-icon-custom` which is more project specific and not so generic. Also added the variable to the default `sass/_variables.scss`. Added explanation to the `README.md`.