### PR TITLE
Use parentheses for all LESS mixin calls

### DIFF
--- a/less/flag-icon-base.less
+++ b/less/flag-icon-base.less
@@ -5,7 +5,7 @@
 }
 
 .flag-icon {
-  .flag-icon-background;
+  .flag-icon-background();
   position: relative;
   display: inline-block;
   width: unit((4 / 3), em);


### PR DESCRIPTION
Fixes compatibility with LESS 4.0.0, which requires all mixin calls to use parentheses.