### PR TITLE
Correct license property for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
   "name": "flag-icon-css",
   "version": "3.5.0",
   "author": "Panayiotis Lipiridis <lipiridis@gmail.com>",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/lipis/flag-icon-css"


### PR DESCRIPTION
`licenses` block is invalid, see https://docs.npmjs.com/cli/v7/configuring-npm/package-json

Closes #830