### PR TITLE
Replace / with math.div in _flag-icon-base.scss

### DIFF
--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .flag-icon-background {
   background-size: contain;
   background-position: 50%;
@@ -8,7 +10,7 @@
   @extend .flag-icon-background;
   position: relative;
   display: inline-block;
-  width: (4 / 3) * 1em;
+  width: math.div(4, 3) * 1em;
   line-height: 1em;
   &:before {
     content: '\00a0';


### PR DESCRIPTION
Using `/` for division is deprecated and will be removed in Dart Sass 2.0.0
https://sass-lang.com/d/slash-div