### PR TITLE
Fix dart-sass deprecation in sass

### DIFF
--- a/sass/_flag-icon-base.scss
+++ b/sass/_flag-icon-base.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .flag-icon-background {
   background-size: contain;
   background-position: 50%;
@@ -8,7 +10,7 @@
   @extend .flag-icon-background;
   position: relative;
   display: inline-block;
-  width: (4 / 3) * 1em;
+  width: math.div(4, 3) * 1em;
   line-height: 1em;
   &:before {
     content: '\00a0';


### PR DESCRIPTION
Division using slash is being deprecated by dart-sass.
A lot of libraries and frameworks are migrating to be compatible with newer dart-sass versions.

This PR changes the sass-code to be compatible with future versions.

https://sass-lang.com/documentation/breaking-changes/slash-div