### PR TITLE
Fixed variable names (after project renaming)

### DIFF
--- a/sass/_flag-icons-base.scss
+++ b/sass/_flag-icons-base.scss
@@ -22,9 +22,9 @@
 
 @mixin flag-icon($country) {
   .flag-icon-#{$country} {
-    background-image: url(#{$flag-icon-css-path}#{$flag-icon-rect-path}/#{$country}.svg);
+    background-image: url(#{$flag-icons-path}#{$flag-icons-rect-path}/#{$country}.svg);
     &.flag-icon-squared {
-      background-image: url(#{$flag-icon-css-path}#{$flag-icon-square-path}/#{$country}.svg);
+      background-image: url(#{$flag-icons-path}#{$flag-icons-square-path}/#{$country}.svg);
     }
   }
 }


### PR DESCRIPTION
During the project renaming (#859) the variables in `sass/_flag-icons-base.scss` were forgotten

- `$flag-icon-css-path` => `$flag-icons-path`
- `$flag-icon-rect-path` => `$flag-icons-rect-path`
- `$flag-icon-square-path` => `$flag-icons-square-path`