### PR TITLE
Support for Frameworks through Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,65 @@ background-repeat: no-repeat;
 
 Which means that the flag is just going to appear in the middle of an element, so you will have to set manually the correct size of 4 by 3 ratio or if it's squared add also the `flag-icon-squared` class.
 
+### Framework Usage
+
+**Vite**
+
+Add these plugins for Vite so the svg's can be treated as components
+
+```js
+npm install --save-dev vite-plugin-svgr@4 @svgr/plugin-svgo @svgr/plugin-jsx
+```
+
+Add this to your Vite config.
+
+```js
+export default defineConfig({
+  vite: {
+    plugins: [
+      svgr({
+        include: "**/*.svg?react",
+        svgrOptions: {
+          plugins: ["@svgr/plugin-svgo", "@svgr/plugin-jsx"],
+          svgoConfig: {
+            plugins: [
+              "preset-default",
+              "removeTitle",
+              "removeDesc",
+              "removeDoctype",
+              "cleanupIds",
+            ],
+          },
+        },
+      }),
+    ],
+  },
+});
+```
+
+**React**
+
+```js
+// SomeReactComponent.tsx
+import FlagEN from "flag-icons/svg/4x3/gb.svg?react";
+```
+
+**Vue**
+
+```vue
+// SomeReactComponent.vue
+<script setup>
+import FlagEN from "flag-icons/svg/4x3/gb.svg?vue";
+</script>
+<template>
+  <FlagEN />
+</template>
+```
+
+Thanks to Doray for the great article.
+
+Link: [https://doray.me/articles/use-svgs-as-react-components-in-astro-MNUvh/](https://doray.me/articles/use-svgs-as-react-components-in-astro-MNUvh/)
+
 ## Development
 
 Run the `yarn` to install the dependencies after cloning the project and you'll be able to:

--- a/package.json
+++ b/package.json
@@ -33,5 +33,9 @@
     "svgo": "svgo --pretty --indent=2 --precision=1",
     "test": "yarn prettier --list-different",
     "maven": "./maven.sh"
+  },
+  "exports": {
+    "./svg/1x1/*.svg": "./flags/1x1/*.svg",
+    "./svg/4x3/*.svg": "./flags/4x3/*.svg"
   }
 }


### PR DESCRIPTION
## Description
This adds support for NodeJS sub-path imports. So it gets easier to find the svg files in the package.

I also added instructions on how to add the flags as EcmaScript Modules so it gets easier to use them in frameworks such as React or Vue. Some of us require them to be added with svg code for better SSR support and to load less on first render through features like Intersection Observer.

## Type of Contribution
Check the relevant box:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Code refactor

## Testing & Verification
I have only tested it on my local Astro project by adding the vite configs inside my project and export paths inside the package.json (flag-icons)

## Screenshots (if applicable)
<img width="316" height="280" alt="CleanShot 2026-07-08 at 17 49 50@2x" src="https://github.com/user-attachments/assets/ddba03a6-3089-40d1-9add-c78cb8659072" />
