### PR TITLE
fix for outdated file reference for excluding countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To serve it on `localhost:8000`
 $ yarn start
 ```
 
-To have only specific countries in the css file, remove the ones that you don't need from the [`_flag-icons-list.scss`](sass/_flag-icons-list.scss) file and build it again.
+To have only specific countries in the css file, edit the `$flag-icons-included-countries` list in [`sass/_variables.scss`](https://github.com/lipis/flag-icons/blob/main/sass/_variables.scss) and build it again.
 
 ## Credits
 


### PR DESCRIPTION
## What this fixes

Fixes #1377

The **Development** section of the README instructed users to remove
unwanted countries from `sass/_flag-icons-list.scss`. That file no
longer stores the country list directly — it now just loops over the
`$flag-icons-included-countries` variable, which lives in
`sass/_variables.scss`.

This means the instruction was inconsistent with the **Usage** section
above it, which already correctly points to `sass/_variables.scss`.

## Change

Updated the Development section to reference `sass/_variables.scss`
and the `$flag-icons-included-countries` variable instead of the
outdated `_flag-icons-list.scss` file, so both sections of the README
now agree.

## Type of change

- [x] Documentation fix (no functional/code changes)

## Checklist

- [x] I've read the relevant section of the README before and after the change
- [x] This is a docs-only change; no build step required
- [x] Linked the related issue (#1377)